### PR TITLE
Make create and delete post show dynamically in Group.js

### DIFF
--- a/client/src/Components/CreatePost.js
+++ b/client/src/Components/CreatePost.js
@@ -7,8 +7,9 @@ const CreatePost = props => {
                 name="createPost"
                 onChange={props.textOnChange}
                 rows="4"
-                cols="" 
-                value={props.textValue}/>
+                cols="50" 
+                value={props.textValue}
+                style={{resize: 'none'}}/>
             <button onClick={props.onSubmitPost}>Post</button>
         </div>
     );

--- a/client/src/Components/Group.js
+++ b/client/src/Components/Group.js
@@ -109,6 +109,12 @@ const Group = props => {
          + dateTime.getSeconds();
     }
 
+    const isUserAllowedToDeletePost = (post) => {
+        return group.loggedInUserDetails.isGroupAdmin ||
+            (group.loggedInUserDetails.isGroupMember &&
+            post.createdBy == group.loggedInUserDetails.username);
+    }
+
     let postsElements = group.feed.map(post => {
         return (
             <Post 
@@ -120,14 +126,10 @@ const Group = props => {
                 likes={post.likes}
                 likeBtnOnClick={() => likeBtnOnClickHandler(post.id)}
                 deleteBtnOnClick={() => deleteBtnOnClickHandler(post.id)}
-                // isUserAllowedToDelete={isUserAllowedToDeletePost(post)}
+                isUserAllowedToDelete={isUserAllowedToDeletePost(post)}
                 />
         )
     });
-
-    const isUserAllowedToDeletePost = (post) => {
-
-    }
 
     const deleteGroupBtnHandler = () => {
         GroupsService.deleteGroupById(group.id).then(data => {
@@ -230,6 +232,11 @@ const Group = props => {
         });
     }
 
+    const canUserPostInGroup = () => {
+        return group.loggedInUserDetails.isGroupAdmin ||
+            group.loggedInUserDetails.isGroupMember;
+    }
+
     return (
         <div>
             <div>
@@ -238,10 +245,14 @@ const Group = props => {
             </div>
             <div>
                 <p>Feed</p>
-                <CreatePost 
+                {
+                    canUserPostInGroup()
+                    ? <CreatePost 
                     textValue={post.text} 
                     onSubmitPost={onSubmitPostHandler} 
                     textOnChange={postTextOnChangeHandler} />
+                    : <p>You have to be a member of this group to be able add and delete previous posts.</p>
+                }
                 {postsElements}
             </div>
             <div>

--- a/client/src/Components/Post.js
+++ b/client/src/Components/Post.js
@@ -1,6 +1,13 @@
 import React from 'react';
 
 const Post = props => {
+    let deletePostBtn = null;
+    if (props.isUserAllowedToDelete) {
+        deletePostBtn = (  
+            <button onClick={props.deleteBtnOnClick}>Delete post</button>
+        );
+    }
+
     return (
         <div>
             <p>Created by: {props.createdBy}</p>
@@ -10,7 +17,7 @@ const Post = props => {
                 <button onClick={props.likeBtnOnClick}>Like</button>
                 <span>{props.likes}</span>
             </div>
-            <button onClick={props.deleteBtnOnClick}>Delete post</button>
+            {deletePostBtn}
         </div>
     );
 }


### PR DESCRIPTION
- in Group: display the CreatePost only if the user is an admin or member of the group, otherwise display a paragraph with a message like "You have to be a member to be able to post"

- in Post: only display the delete button of a post if the user is an admin, or if they are a member of the group and they are the post author

- in CreatePost: I added some inline styling (which you can move to its own css file if you want) to make the textarea non-resizable